### PR TITLE
Project setup / local env tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 .chalice/deployments/*
 .chalice/venv/*
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Proof of concept mapnik renderer for PostGIS datasources using Python.  Ie, don'
 
 ## Instructions
 1. Have recent versions of `docker` and `docker-compose` installed
+1. _MacOS only:_ `sudo mkdir -p /opt/dbdata/lambnik && sudo chown "${USER}":staff /opt/dbdata/lambink`
+1. _MacOS only:_ Open Docker preferences and add `/opt/dbdata` to the list in the File Sharing tab
 1. Build the containers and populate the database: `./scripts/update.sh`
 1. Run the local Chalice server: `./scripts/server.sh`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./src/proxy
       dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "9001:80"
     links:
       - tiler:tiler.lambnik.azavea.com
 

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -26,15 +26,19 @@
 
   <script>
 
+    var LAMBNIK_DOMAIN = 'https://d1y4se194ujvw1.cloudfront.net';
+    // If you're running locally and want to test, use this host instead
+    // var LAMBNIK_DOMAIN = 'http://localhost:9001';
+
     var center = new L.LatLng(39.95, -75.15),
         map = new L.Map('map', {center: center, zoom: 13}),
         baselayer = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png').addTo(map),
-        tileLayer = L.tileLayer('https://d1y4se194ujvw1.cloudfront.net/tile/{z}/{x}/{y}?type={type}', {
+        tileLayer = L.tileLayer(LAMBNIK_DOMAIN + '/tile/{z}/{x}/{y}?type={type}', {
             type: function() {
                 return document.getElementById('inlet-type').value;
         }}).addTo(map);
 
-     var grid = new L.UtfGrid('https://d1y4se194ujvw1.cloudfront.net/grid/{z}/{x}/{y}?type={type}', {
+     var grid = new L.UtfGrid(LAMBNIK_DOMAIN + '/grid/{z}/{x}/{y}?type={type}', {
             useJsonP: false,
             type: function() {
                 return document.getElementById('inlet-type').value;


### PR DESCRIPTION
## Overview

Adds notes found during setup on a MacOS host using the recommended Docker app.

Tweaks the docker-compose env and demo HTML to make it easier to target the local dev environment.

## Demo

Working on a Mac, targeting localhost:
![screen shot 2017-11-06 at 11 46 43](https://user-images.githubusercontent.com/1818302/32452686-38d4ceb2-c2e8-11e7-90ea-3e188837f4b8.png)


## Testing

Can test localhost demo by:
1. Kill any running server, then restart: `./scripts/server.sh`
1. Comment out cloudfront `LAMBNIK_HOST` in demo and uncomment the localhost one
1. Ensure requests to your local env succeed after opening the demo HTML file in your preferred browser