### PR TITLE
Update mapnik postgis datasource connection parameters

### DIFF
--- a/src/tiler/chalicelib/tile.py
+++ b/src/tiler/chalicelib/tile.py
@@ -69,7 +69,11 @@ def create_map(z, x, y, inlet_type):
                          user=environ.get('POSTGRES_USER'),
                          password=environ.get('POSTGRES_PASSWORD'),
                          dbname=environ.get('POSTGRES_DB'),
-                         table=tbl)
+                         table=tbl,
+                         connect_timeout=2,
+                         persist_connection=False,
+                         initial_size=1,
+                         max_size=1)
     lyr = Layer('PostGIS')
 
     lyr.datasource = postgis_ds

--- a/src/tiler/chalicelib/tile.py
+++ b/src/tiler/chalicelib/tile.py
@@ -70,7 +70,7 @@ def create_map(z, x, y, inlet_type):
                          password=environ.get('POSTGRES_PASSWORD'),
                          dbname=environ.get('POSTGRES_DB'),
                          table=tbl,
-                         connect_timeout=2,
+                         connect_timeout=5,
                          persist_connection=False,
                          initial_size=1,
                          max_size=1)


### PR DESCRIPTION
## Overview

Uses some additional [parameters of the mapnik Postgis datasource](https://github.com/mapnik/mapnik/wiki/PostGIS) to configure the connection for our use case. Most notably:
1. Disable connection persistance within the mapnik datasource
1. Ensure that the datasource connection pool can only ever have one connection
1. Match connection timeout to the lambda config timeout in config.json

(1) is the real winner here, in that it appears to completely remove the issue where db connections persist after a lambda function shuts down. With this flag enabled, rapid panning and zooming with CloudFront TTLs set to zero quickly lead to maxing out the available DB connections and sporadic 500 errors. With this setting disabled, the db connection count stays near zero under the same test conditions.

## Notes

I arrived at the Postgis datasource documentation after a dive into the Mapnik python source in an attempt to answer the question: "Can I manually close the datasource db connection in code, e.g. `datasource.close()`?" A few turns of the maze later and I found that documentation page. 

## Demo

The graphs below show three different tests within an approximately 1.5 hour window:
1. Staging configured as on develop. I zoomed, panned and changed the filter a few times around 15:05.
1. Staging configured with this PR's changes. I zoomed, panned and changed the filter a few times around 16:05. Note that at this time, db connections remains nearly at zero, mem remains mostly free, and CPU spikes a bit.
1. Staging reverted to develop. I zoomed, panned and changed the filter a few times around 16:15. Note that the db connections and mem spike again. 

Across all tests, you can see that lambda functions are being called, as denoted by the last graph.

** RDS CPU (percent): **
<img width="934" alt="screen shot 2017-11-06 at 16 39 12" src="https://user-images.githubusercontent.com/1818302/32466117-c9c28e8e-c313-11e7-87ff-ddb7e23c2f72.png">

** RDS MEM (mb): **
<img width="923" alt="screen shot 2017-11-06 at 16 39 24" src="https://user-images.githubusercontent.com/1818302/32466124-d7602fb0-c313-11e7-9ebe-be9a0d743b04.png">

** RDS DB Connections (count): **
<img width="934" alt="screen shot 2017-11-06 at 16 38 52" src="https://user-images.githubusercontent.com/1818302/32466131-df74735a-c313-11e7-85af-34412b6cc565.png">

** Lambda Invocations (count): **
<img width="1437" alt="screen shot 2017-11-06 at 17 00 44" src="https://user-images.githubusercontent.com/1818302/32466191-11fd1c46-c314-11e7-97b2-dece931d9f90.png">

## Testing

This configuration is currently applied to the staging environment (including CloudFront TTLs == zero). Open up `demo.html`, zoom and pan around a bunch and then check the RDS CPU/mem/db connection metrics after a minute or so. Connections and memory should remain low, CPU may spike a bit.

Mention to @hectcastro if this applies to other Azavea cases

Connects #1 
